### PR TITLE
A2.2 Character Health UI

### DIFF
--- a/Unnamed Roguelike Game/Game.tscn
+++ b/Unnamed Roguelike Game/Game.tscn
@@ -1,14 +1,30 @@
-[gd_scene load_steps=3 format=3 uid="uid://b8po4tfjlujc8"]
+[gd_scene load_steps=4 format=3 uid="uid://ck7dgjuf7h6os"]
 
-[ext_resource type="PackedScene" uid="uid://bxrc5aulpi3wk" path="res://Room.tscn" id="1_2tscc"]
+[ext_resource type="PackedScene" path="res://Room.tscn" id="1_2tscc"]
 [ext_resource type="PackedScene" uid="uid://b06g5m8ciufci" path="res://Player.tscn" id="2_5qbtk"]
+[ext_resource type="Script" path="res://HP.gd" id="3_emkpw"]
 
 [node name="Game" type="Node2D"]
 
 [node name="Room" parent="." instance=ExtResource("1_2tscc")]
 
-[node name="Player" parent="." instance=ExtResource("2_5qbtk")]
-position = Vector2(46, 38)
-
 [node name="Camera2D" type="Camera2D" parent="."]
 position = Vector2(559, 323)
+
+[node name="Player" type="Node2D" parent="."]
+
+[node name="Player" parent="Player" instance=ExtResource("2_5qbtk")]
+position = Vector2(46, 38)
+
+[node name="UI" type="CanvasLayer" parent="."]
+
+[node name="HP" type="Label" parent="UI"]
+offset_left = 1.0
+offset_top = -11.0
+offset_right = 99.0
+offset_bottom = 44.0
+theme_override_colors/font_color = Color(1, 0, 0, 0.780392)
+theme_override_colors/font_outline_color = Color(0, 0, 0, 0.937255)
+theme_override_constants/outline_size = 10
+theme_override_font_sizes/font_size = 30
+script = ExtResource("3_emkpw")

--- a/Unnamed Roguelike Game/HP.gd
+++ b/Unnamed Roguelike Game/HP.gd
@@ -1,0 +1,11 @@
+extends Label
+
+
+# Called when the node enters the scene tree for the first time.
+func _ready():
+	pass # Replace with function body.
+
+
+# Called every frame. 'delta' is the elapsed time since the previous frame.
+func _process(delta):
+	text = "HP: " + str(get_node("../../Player/Player").get("player_health"))

--- a/Unnamed Roguelike Game/Player.gd
+++ b/Unnamed Roguelike Game/Player.gd
@@ -2,7 +2,7 @@ extends CharacterBody2D
 
 var player_speed = 500.0
 
-var player_health = 100
+@onready var player_health = 100
 
 func _physics_process(delta):
 

--- a/Unnamed Roguelike Game/Player.tscn
+++ b/Unnamed Roguelike Game/Player.tscn
@@ -27,7 +27,6 @@ scale = Vector2(4, 4)
 script = ExtResource("1_mnvdn")
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="."]
-position = Vector2(2, 4)
 shape = SubResource("CapsuleShape2D_lacq0")
 
 [node name="AnimatedSprite2D" type="AnimatedSprite2D" parent="."]


### PR DESCRIPTION
Added a Canvas Layer for General UI. Added the HP label node to the UI Canvas Layer. Added HP.gd script that matches the displayed HP to the HP of the player.

Closes #6 